### PR TITLE
Add protocol details for Python/Go/Rust refactors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# AGENTS Instructions
+
+- Use tabs for indentation (tab width 4).
+- Run `make` to ensure the project builds after changes. If `configure` or Makefile are missing, run `./autogen.sh` first.
+- Additional project overview and build details can be found in `AGENTS/README.md`.

--- a/AGENTS/PROTOCOL.md
+++ b/AGENTS/PROTOCOL.md
@@ -1,0 +1,52 @@
+# Xiaomi P2P Protocol Notes
+
+These notes summarize how `videop2proxy` talks to Xiaomi cameras. They are meant to aid refactoring the proxy in languages such as Python, Go or Rust.
+
+## Credential Discovery
+1. The camera's miIO token and IP address are required.
+2. Run the following miIO command to obtain P2P credentials:
+   ```sh
+   python3 -c "import miio; result = miio.device.Device('<IP>', '<TOKEN>').send('get_ipcprop', ['all']); print(result['p2p_id']); print(result['avID']); print(result['avPass']);"
+   ```
+   This yields the camera's `p2p_id` (UID), AV username and password.
+
+## Connection Sequence
+1. `IOTC_Initialize2(0)` – initialise the IOTC stack.
+2. `avInitialize(3)` – initialise AV client support.
+3. `SID = IOTC_Get_SessionID()` – reserve a session slot.
+4. `IOTC_Connect_ByUID_Parallel(p2p_id, SID)` – open a P2P link to the camera.
+5. `avClientStart2(SID, userName, passWord, 5000, &srvType, 0, &bResend)` – authenticate and obtain an `avIndex`.
+6. Start streaming by sending two IO control messages using `avSendIOCtrl` with payload `{"channel":0}`:
+   - `IOTYPE_USER_IPCAM_START`
+   - `IOTYPE_USER_IPCAM_AUDIOSTART`
+7. Frames are received with `avRecvFrameData2(avIndex, ...)`.
+8. To stop streaming send `IOTYPE_USER_IPCAM_STOP` and `IOTYPE_USER_IPCAM_AUDIOSTOP`.
+
+## Frame Metadata Layout
+Each `avRecvFrameData2` call returns raw H.264 data and a 64‑byte little‑endian metadata block. Important fields:
+
+| Offset | Size | Field | Description |
+|-------:|-----:|-------|-------------|
+| 0      | 2    | `codec_id` | Expected to be H264 (`0x6800`). |
+| 2      | 1    | `flags` | `1` indicates an I‑frame. |
+| 3      | 1    | `cam_index` | Camera index. |
+| 4      | 1    | `onlineNum` | Number of online viewers. |
+| 5      | 1    | `isLiveflages` | <150 means live, otherwise playback. |
+| 6      | 1    | `backwardIndex` |
+| 7      | 1    | `backwardIndex2` |
+| 8      | 4    | `millisecond` |
+| 12     | 4    | `timestamp` | Seconds since epoch. Combine with `millisecond` for frame time. |
+| 16     | 4    | `videoWidth` |
+| 20     | 4    | `videoHeight` |
+
+The frame payload immediately follows the metadata and its length is returned separately (`frmSize`).
+
+## Output Modes
+* **STDOUT** – raw H.264 frames are written to standard output when `--stdout` is supplied.
+* **RTSP** – if compiled with `ENABLE_RTSP`, frames are written to a FIFO consumed by a live555‑based server (`rtsp.cxx`).
+
+## Miscellaneous
+* Audio support is stubbed out (`thread_ReceiveAudio`), but IO control messages for audio are issued for completeness.
+* The project relies on vendor libraries found in `lib/` and headers under `include/`.
+
+These details mirror the behaviour of the current C implementation and can serve as a reference when porting the proxy to other languages.

--- a/AGENTS/README.md
+++ b/AGENTS/README.md
@@ -1,0 +1,30 @@
+# videoP2Proxy Repository Overview
+
+This repository contains `videop2proxy`, a proxy that allows Xiaomi P2P cameras to be accessed using standard protocols such as RTSP or raw H264 over stdout.
+
+## Layout
+- `main.c` – command-line interface and connection loop.
+- `client.c` / `client.h` – orchestrates P2P client operations.
+- `iotc.c` / `iotc.h` – wrappers around IOTC API calls.
+- `av.c` / `av.h` – handles AV client setup and receiving frames.
+- `avframe.c` / `avframe.h` – frame parsing and communication with other modules.
+- `rtsp.cxx` / `rtsp.h` – optional RTSP server built with **live555** when `ENABLE_RTSP` is defined.
+- `include/` – third‑party headers for IOTC/AV APIs.
+- `lib/` – vendor libraries required at link time.
+- Build scripts: `autogen.sh`, `configure.ac`, and `Makefile.am` (Autotools).
+- `PROTOCOL.md` – Xiaomi P2P handshake and frame format notes for refactors.
+
+## Build & Test
+1. Run `./autogen.sh` once to generate the `configure` script and initial Makefile.
+2. Build with `make`. This ensures the project compiles cleanly.
+
+## Protocol Reference
+Detailed Xiaomi P2P connection steps and the metadata layout of incoming frames are documented in `PROTOCOL.md`. This overview is useful when re-implementing the proxy in languages such as Python, Go, or Rust.
+
+## Coding Guidelines
+- The codebase is primarily C with one C++ file (`rtsp.cxx`).
+- Source files specify `indent-tabs-mode: t` and `tab-width: 4`; use tabs for indentation at a width of four spaces.
+- Keep functions small and avoid trailing whitespace.
+
+## Notes
+This document is intended for developers and Codex agents to understand the structure and build process of the project. Future contributions should follow the build and coding guidelines above.


### PR DESCRIPTION
## Summary
- Document Xiaomi P2P handshake and frame format in `AGENTS/PROTOCOL.md`
- Note protocol reference in repository overview for future language ports

## Testing
- `./autogen.sh` *(fails: You must have `automake` installed)*
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_689876efd118832792b86eb5eb7ecc24